### PR TITLE
Use default editor if not set by environment variable

### DIFF
--- a/bin/issues
+++ b/bin/issues
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# encoding: utf-8 
+# encoding: utf-8
 #===========================================================================================
 require 'rubygems'
 require 'fattr'
@@ -16,11 +16,11 @@ require 'git'
 
 def git_get_current_branch()
   current_branch = `git branch`.split(/\n/).find{ |l| l.start_with?("*") }
-  
+
   if current_branch
     current_branch =~ /\*\s+(.+)/
     $~[1]
-  end 
+  end
 end
 
 #-------------------------------------------------------------------------------------------
@@ -37,10 +37,17 @@ end
 
 #-------------------------------------------------------------------------------------------
 
+def get_system_editor()
+  default_editor = 'editor'
+  ENV['EDITOR'] || `git var GIT_EDITOR`.rstrip || default_editor
+end
+
+#-------------------------------------------------------------------------------------------
+
 def edit_string(aString)
+  editor = get_system_editor
   tempfile_name = "/tmp/issues-" << SecureRandom.hex.force_encoding("UTF-8")
-  File.write(tempfile_name, aString)
-  system("$EDITOR #{tempfile_name}")
+  system("#{editor} #{tempfile_name}")
   new_string = File.read(tempfile_name)
   File.unlink(tempfile_name)
   new_string
@@ -50,7 +57,7 @@ end
 
 class LogEntry
   fattr :date, :message
-  
+
   def initialize(message)
     @date = Time.new
     @message = message.dup
@@ -63,7 +70,7 @@ end
 class Issue
   fattr :id, :created, :type, :title, :description, :status, :milestone, :estimate
   attr_accessor :history
-  
+
 #-------------------------------------------------------------------------------------------
 
   def initialize
@@ -91,7 +98,7 @@ class Issue
       new_value = value.is_a?(Numeric) || value == nil ? value : value.dup
       a_issue.send(a) && self.send(a, new_value)
     end
-  end  
+  end
 
 #-------------------------------------------------------------------------------------------
 
@@ -99,36 +106,36 @@ class Issue
     @history ||= []
     @history << LogEntry.new(message)
   end
-  
+
 #-------------------------------------------------------------------------------------------
-  
+
   def format_verbose(opts)
     milestone = @milestone ? "#{@milestone}" : "NO MILESTONE"
     estimate = @estimate ? "#{@estimate}h" : "NO ESTIMATE"
     milestone_estimate = "[#{estimate}, #{milestone}]"
-    
+
     result = []
     result << PrettyComment.separator
     result << PrettyComment.comment("#{@id[0,6]} #{@type.capitalize} (#{@status}) #{milestone_estimate} #{@created.to_s[0,16]}")
     result << PrettyComment.comment("")
     result << PrettyComment.format_line(@title, "#", false, "#")
-    
+
     if @description
       result << PrettyComment.sub_heading("Description:")
       @description.split("\n").each do |l|
         result << PrettyComment.format_line(l, "#", false, "#")
       end
     end
-    
+
     if @history && @history.count > 0
       result << PrettyComment.sub_heading("Log:")
       @history.each { |l| result << PrettyComment.format_line("#{l.message}", "# #{l.date.to_s[0,16]}", true, "#", "#") }
     end
-    
+
     result << PrettyComment.separator
     result << ""
     result << ""
-    
+
     result.join("\n")
   end
 
@@ -148,8 +155,8 @@ class Issue
     end
 
     #suffix = estimate_milestone.count > 0 ? "[#{estimate_milestone.join(' => ')}]" : ""
-    
-    PrettyComment.format_line(entry, info_string, true) 
+
+    PrettyComment.format_line(entry, info_string, true)
   end
 
 #-------------------------------------------------------------------------------------------
@@ -170,12 +177,12 @@ class Issue
   def edit_all
     original_yaml = self.to_yaml
     new_yaml = edit_string(original_yaml)
-    
+
     if (new_yaml != original_yaml)
       self.copy_from(YAML::parse(new_string))
       return true
-    end 
-    
+    end
+
     return false
   end
 
@@ -184,7 +191,7 @@ class Issue
   def short_id
     @id[0,6]
   end
-    
+
 end
 
 #===========================================================================================
@@ -193,60 +200,60 @@ end
 
 class IssuesDb
   fattr :issues_array
-  
+
 #-------------------------------------------------------------------------------------------
 
   def initialize(database_file)
     @database_file = database_file
     @issues_array = FileTest.exists?(database_file) && YAML.load_file(database_file) || []
   end
-  
+
 #-------------------------------------------------------------------------------------------
 
   def select_issues(&select_proc)
     return @issues_array.select(&select_proc)
   end
-  
+
 #-------------------------------------------------------------------------------------------
 
   def select_issue(&select_proc)
     result = select_issues(&select_proc)
-    
+
     if result.count == 1
       return result[0]
-  
+
     elsif result.count > 1
       puts "Found more than one issue that match this query:"
       result.each{|i| puts("#{i.id} #{i.title}")}
       exit
-    
+
     else
       puts "Error: No issue found for query."
       exit
     end
 
     nil
-  end  
+  end
 
 #-------------------------------------------------------------------------------------------
 
   def has_issue(issue_id)
     @issues_array.any? { |issue| issue.id.start_with?(issue_id) }
   end
-  
+
 #-------------------------------------------------------------------------------------------
 
   def save_db()
     FileTest.exists?('.issues') || Dir.mkdir('.issues')
     File.open(@database_file, 'w' ) { |out| YAML.dump(@issues_array, out) }
   end
-  
+
 #-------------------------------------------------------------------------------------------
 
   def determine_issue_type(opts)
     issue_types = %w{bug improvement task feature}
     issue_type = opts[:type] ? opts[:type].downcase : nil
-    
+
     issue_type && (return issue_type)
 
     case opts[:title]
@@ -269,19 +276,19 @@ class IssuesDb
     new_issue.milestone = opts[:milestone]
     new_issue.estimate = opts[:estimate]
     @issues_array << new_issue
-    save_db()  
+    save_db()
     puts "Created issue #{new_issue.short_id} #{new_issue.title}"
   end
 
 #-------------------------------------------------------------------------------------------
-  
+
   def select_issues_with_opts(opts)
-    did_select_issue_types = opts[:type]       
+    did_select_issue_types = opts[:type]
     status_regex = opts[:all] ? /^(open|resolved|duplicate|wontfix)/ : /^open$/
     did_select_milestone = opts[:milestone] != nil
     milestone = opts[:milestone]
-                  
-    return @issues_array.select do |issue| 
+
+    return @issues_array.select do |issue|
       (status_regex =~ issue.status) \
         && (issue.type == opts[:type] || !did_select_issue_types) \
         && (issue.milestone == opts[:milestone] \
@@ -362,7 +369,7 @@ class IssuesDb
 
     duplicate_of_id = opts[:cmd] == "duplicate" && select_issue {|i| i.id.start_with?(opts[:duplicate_of_id]) }.id
 
-    status, message = 
+    status, message =
     case opts[:cmd]
     when "resolve"
       ["resolved", "Resolved"]
@@ -376,17 +383,17 @@ class IssuesDb
 
     resolved_issue.status = status
     resolved_issue.log "Changed status to #{status}"
-    
+
     message = "#{message} issue #{resolved_issue.short_id}: #{resolved_issue.title}"
     puts message
-    
+
     save_db()
 
     if opts[:commit]
       system "git add .issues"
       system "git commit -m \"#{message}\""
     end
-    
+
     if opts[:close_branch] == true
       issue_branch = git_get_current_branch()
       system "git checkout dev"
@@ -403,17 +410,17 @@ class IssuesDb
     opts[:issue_ids].each do |issue_id|
       delete_issues << select_issue{|i| i.id.start_with?(issue_id)}
     end
-    
+
     puts "Ok to delete issues: "
     delete_issues.each { |issue| puts "#{issue.short_id} \"#{issue.title}\"" }
     puts "[y/N]"
-    
+
     answer = STDIN.getch
-    
+
     if /y/i =~ answer
       @issues_array -= delete_issues
       save_db()
-      
+
       if delete_issues.count == 1
         puts "Removed issue #{delete_issues[0].short_id} \"#{delete_issues[0].title}\" from database."
       else
@@ -429,16 +436,16 @@ class IssuesDb
 
   def edit_issue(opts)
     issue_id = opts[:issue_id]
-    issue = select_issue { |i| i.id.start_with?(issue_id) } 
-  
+    issue = select_issue { |i| i.id.start_with?(issue_id) }
+
     did_change_issue = false
-  
+
     if (opts[:description])
       did_change_issue = issue.edit_description && issue.log("Edited description")
     else
       did_change_issue = issue.edit_all && issue.log("Edited issue")
     end
-   
+
     did_change_issue && save_db()
   end
 
@@ -453,9 +460,9 @@ class IssuesDb
   end
 
 #-------------------------------------------------------------------------------------------
-  
+
   def get_milestones_for_pattern(pattern)
-    result_hash = {}    
+    result_hash = {}
     issues_array.each { |i| select_issue_for_estimate?(i, pattern) && result_hash[i.milestone] = true }
     result_hash.keys.sort
   end
@@ -465,24 +472,24 @@ class IssuesDb
   def estimate(opts)
     milestone = opts[:milestone]
     total = 0.0
-    
+
     issues_to_estimate = @issues_array.select { |i| select_issue_for_estimate?(i, milestone) }
     issues_without_estimates = @issues_array.select { |i| select_issue_for_estimate?(i, milestone) && !i.estimate }
 
-    if issues_to_estimate.empty? 
+    if issues_to_estimate.empty?
       puts "No open issues found for milestone " << milestone << "!"
       exit
     end
 
-    if issues_without_estimates.count > 0 
+    if issues_without_estimates.count > 0
       puts PrettyComment.h3("Warning: Found issues without estimates")
       issues_without_estimates.each {|i| puts i.format_list(opts)}
       puts PrettyComment.separator("-")
       puts
     end
-    
+
     issues_to_estimate.each { |i| (i.estimate && total += i.estimate) }
-    
+
     milestones = get_milestones_for_pattern(milestone)
 
     result_str = "Milestone" << (milestones.length > 1 ? "s" : "")
@@ -497,12 +504,12 @@ class IssuesDb
     new_type = opts[:type]
     new_milestone = opts[:milestone]
     new_estimate = opts[:estimate]
-    
+
     opts[:issue_ids].each do |issue_id|
       did_update = false
       issue = select_issue { |i| i.id.start_with?(issue_id) }
 
-      if new_type 
+      if new_type
         if issue.type != new_type
           issue.type = new_type
           issue.log("Changed type to #{issue.type}")
@@ -543,13 +550,13 @@ class IssuesDb
 
   def start_branch(opts)
     git_get_current_branch() == "dev" || Trollop::die("Must be on dev branch to start new issue branch.")
-    
+
     issue_id = opts[:issue_id]
     issue = select_issue{|i| i.id.start_with?(issue_id) && i.status == "open"}
 
     system("git checkout -b #{issue.type}/#{issue.short_id}")
   end
-    
+
 #-------------------------------------------------------------------------------------------
 
 
@@ -563,11 +570,11 @@ end
 def get_issue_ids(num_ids, usage)
   result = []
   count = num_ids >= 0 ? num_ids : ARGV.count
-  
+
   begin
     count.times do
-      ARGV.count > 0 && /^\h{1,32}$/ =~ ARGV[0] || raise 
-      result << ARGV.shift 
+      ARGV.count > 0 && /^\h{1,32}$/ =~ ARGV[0] || raise
+      result << ARGV.shift
     end
 
     result.count == 1 && num_ids > 0 ? result[0] : result
@@ -596,21 +603,21 @@ SUB_COMMANDS = {
   "update"        => "update issue fields.",
   "startbranch"   => "start a new git branch with to work on issue"}
 
-LeftFieldLength = 
+LeftFieldLength =
   SUB_COMMANDS.collect { |key, value| key.length }.max
-  
+
 SubCommandHelp =
   SUB_COMMANDS.collect {|key,value| "  #{key.ljust(LeftFieldLength)}  #{value}"}.join("\n")
 
-  
+
 global_opts = Trollop::options do
   banner <<-EOL
 issues: lightweight distributed issue management.
-  
+
 Usage:
 ------
 issues [<command>] [<options] [<args>]
-  
+
 Commands are:
 -------------
 #{SubCommandHelp}
@@ -628,23 +635,23 @@ cmd ||= 'list'
 cmd_opts = {}
 
 if cmd == 'list' || cmd == 'count'
-  cmd_opts = 
+  cmd_opts =
     Trollop::options do
       opt :all,    "#{cmd} all issues",            :short => 'a'
       opt :newest, "#{cmd} newest issues first" if cmd == 'list'
       opt :oldest, "#{cmd} oldest issues first" if cmd == 'list'
       opt :verbose, "verbose list of issues", :short => 'v' if cmd == 'list'
-      opt :type, "#{cmd} issues of given type (bug, improvement, task, feature)", :short => 't', :type => String 
+      opt :type, "#{cmd} issues of given type (bug, improvement, task, feature)", :short => 't', :type => String
       opt :milestone, "#{cmd} issues for given milestone", :short => 'm', :type => String
       opt "no-milestone", "#{cmd} all issues not assigned to any milestone"
     end
-    
+
     if cmd == 'list'
       ARGV.count > 0 && cmd_opts[:issue_id] = get_issue_ids(1, "list ID")
     end
 
 elsif cmd == "create"
-  cmd_opts = 
+  cmd_opts =
     Trollop::options do
       opt :type, "create issue of specific type (e.g. bug, feature, improvement, task)", :short => 't', :type => String
       opt :milestone, "specify the milestone of the new issue", :short => 'm', :type => String
@@ -654,11 +661,11 @@ elsif cmd == "create"
 
 
 elsif cmd == "resolve" || cmd == "wontfix" || cmd == "duplicate" || cmd == "cantreproduce"
-  cmd_opts = 
+  cmd_opts =
     Trollop::options do
       opt :commit, "do a git commit", :short => 'c'
     end
-    
+
   if cmd == "duplicate"
     cmd_opts[:issue_id], cmd_opts[:duplicate_of_id] = get_issue_ids(2, "duplicate ID(issue) ID(duplicate of)")
   elsif cmd == "resolve" && is_issue_branch()
@@ -668,15 +675,15 @@ elsif cmd == "resolve" || cmd == "wontfix" || cmd == "duplicate" || cmd == "cant
   else
     cmd_opts[:issue_id] = get_issue_ids(1, "#{cmd} [-c] ID")
   end
-  
-  
+
+
 elsif cmd == "edit"
-  cmd_opts = 
+  cmd_opts =
     Trollop::options do
       opt :description, "edit the issue description", :short => 'd'
     end
-  cmd_opts[:issue_id] = get_issue_ids(1, "edit ID") 
-  
+  cmd_opts[:issue_id] = get_issue_ids(1, "edit ID")
+
 elsif cmd == "estimate"
   Trollop::options do
     banner <<-EOL
@@ -731,7 +738,7 @@ else
 end
 
 
-cmd_opts[:cmd] = cmd 
+cmd_opts[:cmd] = cmd
 
 
 #===========================================================================================
@@ -744,9 +751,9 @@ cmd_opts[:milestone_column_width] = Issues.milestone_column_width()
 cmd_opts[:list_milestone] = Issues.has_open_issues_with_milestone?()
 
 case cmd
-  when "create" 
+  when "create"
     Issues.create_issue(cmd_opts)
-  when "list" 
+  when "list"
     Issues.list_issues(cmd_opts)
   when "count"
     Issues.count_issues(cmd_opts)
@@ -765,4 +772,3 @@ case cmd
 end
 
 #===========================================================================================
-

--- a/bin/issues
+++ b/bin/issues
@@ -47,6 +47,7 @@ end
 def edit_string(aString)
   editor = get_system_editor
   tempfile_name = "/tmp/issues-" << SecureRandom.hex.force_encoding("UTF-8")
+  File.write(tempfile_name, aString)
   system("#{editor} #{tempfile_name}")
   new_string = File.read(tempfile_name)
   File.unlink(tempfile_name)


### PR DESCRIPTION
Hi @WolfgangSteiner,

I was playing with Issues recently as it fits nicely with my side projects.

When I tried `issues edit <hash>` I'd receive an error because my `EDITOR` envvar was not set. The error is a permissions issue, because then the command is just `system(' /tmp/<tempfile')`. The proposed change is:

When editing issues, try editors in this order:
* $EDITOR environment variable
* git var GIT_EDITOR
* default value in the program, set to 'editor'

Some extra whitespace was automatically removed by my editor.

Can you let me know if you're still actively supporting this project and what is the licence?

Thanks!